### PR TITLE
docs: remove outdated example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,6 @@ import {
         console.log('All done!');
     });
 
-    // Custom function executed on browser side to extract job description [optional]
-    const descriptionFn = () => {
-        const description = document.querySelector<HTMLElement>(".jobs-description");
-        return description ? description.innerText.replace(/[\s\n\r]+/g, " ").trim() : "N/A";
-    }
-
     // Run queries concurrently    
     await Promise.all([
         // Run queries serially


### PR DESCRIPTION
removes `descriptionFn()` from example as it causes the application to crash trying to find `document` object, and as `data` property returned from `scraper.on("scraper:data")` event already has a filled `description` and `descriptionHTML` properties